### PR TITLE
feat(grid): allow adding className to GridOverlay

### DIFF
--- a/atomic-design/organisms/grid/src/grid-overlay.tsx
+++ b/atomic-design/organisms/grid/src/grid-overlay.tsx
@@ -45,9 +45,9 @@ const Toggle = styled.button<Pick<GridOverlayProps, "position">>`
 	border-radius: 50%;
 `;
 
-export const GridLayer: React.FC<GridOverlayProps> = ({ position }) => {
+export const GridLayer: React.FC<GridOverlayProps> = ({ position, className }) => {
 	return (
-		<GridOverlayGrid position={position}>
+		<GridOverlayGrid position={position} className={className}>
 			<GridOverlayRow>
 				{Array(12)
 					.fill(Boolean)
@@ -61,7 +61,12 @@ export const GridLayer: React.FC<GridOverlayProps> = ({ position }) => {
 	);
 };
 
-export const GridOverlay: React.FC<GridOverlayProps> = ({ initialActive, toggle, position }) => {
+export const GridOverlay: React.FC<GridOverlayProps> = ({
+	className,
+	initialActive,
+	toggle,
+	position,
+}) => {
 	const [active, setActive] = React.useState(initialActive);
 	const handleClick = React.useCallback(() => setActive(state => !state), []);
 	return (
@@ -71,7 +76,7 @@ export const GridOverlay: React.FC<GridOverlayProps> = ({ initialActive, toggle,
 					{active ? "gridOff" : "grid"}
 				</Toggle>
 			)}
-			{active && <GridLayer position={position} />}
+			{active && <GridLayer position={position} className={className} />}
 		</>
 	);
 };


### PR DESCRIPTION
## Motivation
Allows adding a classname to grid-overlay.

<!-- List motivation and changes here -->

## Issues closed

<!-- List closed issues here -->

<!-- closes #1234567890 -->

## Additional Info

<!-- Please add additional information that might be useful for the reviewer -->

<!-- 
Examples:

Storybook: Atoms/Button/Simple (this will help the reviewer find the correct demo for the PR)

-->

